### PR TITLE
Getters/Setters Macro

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,11 +62,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute(
             "runtime.Executable",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
+            "#[derive(::serde::Serialize, ::serde::Deserialize, ::macros::Output, ::macros::Getters, ::macros::Setters)]",
+        )
+        .field_attribute(
+            "runtime.Executable.meta",
+            "#[getset(ignore)]",
         )
         .type_attribute(
             "runtime.ExecutableStatus",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
+            "#[derive(::serde::Serialize, ::serde::Deserialize, ::macros::Output)]",
         )
         .compile(
             &[

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,7 @@
-use proc_macro::{TokenStream};
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
 use quote::quote;
-use syn::{DeriveInput, parse_macro_input};
+use syn::{parse_macro_input, Data, DeriveInput};
 
 #[proc_macro_derive(Output)]
 pub fn output(input: TokenStream) -> TokenStream {
@@ -21,4 +22,141 @@ pub fn output(input: TokenStream) -> TokenStream {
     };
 
     expanded.into()
+}
+
+#[proc_macro_derive(Getters, attributes(getset))]
+pub fn getters(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let ident = &ast.ident;
+
+    let data_struct = match ast.data {
+        Data::Struct(data_struct) => data_struct,
+        _ => panic!("`Getters` only supports structs"),
+    };
+
+    let field_getters: Vec<proc_macro2::TokenStream> = data_struct
+        .fields
+        .iter()
+        .filter(|field| {
+            !getset::attribute_contains_any(*field, &["ignore", "ignore_get"])
+        })
+        .map(|field| {
+            let field_ident = field
+                .ident
+                .as_ref()
+                .expect("`Getters` only supports structs with named fields");
+
+            let function_ident =
+                Ident::new(&format!("get_{}", field_ident), field_ident.span());
+
+            let field_type = &field.ty;
+
+            quote! {
+                pub fn #function_ident(&mut self) -> #field_type {
+                    self.#field_ident.clone()
+                }
+            }
+        })
+        .collect();
+
+    let expanded = quote! {
+        impl #ident {
+            #(#field_getters)*
+        }
+    };
+
+    expanded.into()
+}
+
+#[proc_macro_derive(Setters, attributes(getset))]
+pub fn setters(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let ident = &ast.ident;
+
+    let data_struct = match ast.data {
+        Data::Struct(data_struct) => data_struct,
+        _ => panic!("`Setters` only supports structs"),
+    };
+
+    let field_setters: Vec<proc_macro2::TokenStream> = data_struct
+        .fields
+        .iter()
+        .filter(|field| {
+            !getset::attribute_contains_any(*field, &["ignore", "ignore_set"])
+        })
+        .map(|field| {
+            let field_ident = field
+                .ident
+                .as_ref()
+                .expect("`Setters` only supports structs with named fields");
+
+            let function_ident =
+                Ident::new(&format!("set_{}", field_ident), field_ident.span());
+
+            let field_type = &field.ty;
+
+            quote! {
+                pub fn #function_ident(&mut self, #field_ident: #field_type) {
+                    self.#field_ident = #field_ident;
+                }
+            }
+        })
+        .collect();
+
+    let expanded = quote! {
+        impl #ident {
+            #(#field_setters)*
+        }
+    };
+
+    expanded.into()
+}
+
+mod getset {
+    use proc_macro2::Ident;
+    use syn::parse::{Parse, ParseStream};
+    use syn::punctuated::Punctuated;
+    use syn::{Field, Token};
+
+    struct GetSetAttribute {
+        options: Punctuated<Ident, Token![,]>,
+    }
+
+    impl Parse for GetSetAttribute {
+        fn parse(input: ParseStream) -> syn::Result<Self> {
+            let options = input.parse_terminated(Ident::parse)?;
+            Ok(GetSetAttribute { options })
+        }
+    }
+
+    pub(crate) fn attribute_contains_any(
+        field: &Field,
+        values: &[&str],
+    ) -> bool {
+        field
+            .attrs
+            .iter()
+            .filter(|attribute| {
+                let seg = match attribute.path.segments.len() {
+                    1 => &attribute.path.segments[0],
+                    2 if attribute.path.segments[0].ident == "macros" => {
+                        &attribute.path.segments[1]
+                    }
+                    _ => {
+                        return false;
+                    }
+                };
+
+                seg.ident == "getset"
+            })
+            .any(|attribute| {
+                let GetSetAttribute { options } = attribute
+                    .parse_args_with(GetSetAttribute::parse)
+                    .expect("failed to parse `getset` attribute");
+
+                options
+                    .into_iter()
+                    .any(|option| values.iter().any(|v| option == v))
+            })
+    }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -41,57 +41,12 @@ pub fn exec() -> Executable {
     Executable::default()
 }
 
-impl Executable {
-    pub fn get_comment(&mut self) -> String {
-        self.comment.clone()
-    }
-
-    pub fn set_comment(&mut self, x: String) {
-        self.comment = x;
-    }
-    pub fn get_exec(&mut self) -> String {
-        self.exec.clone()
-    }
-
-    pub fn set_exec(&mut self, x: String) {
-        self.exec = x;
-    }
-
-    pub fn get_name(&mut self) -> String {
-        self.name.clone()
-    }
-
-    pub fn set_name(&mut self, x: String) {
-        self.name = x;
-    }
-
-    pub fn raw(&mut self) {
-        println!("{:?}", self);
-    }
-
-    pub fn json(&mut self) {
-        let serialized = serde_json::to_string_pretty(&self).unwrap();
-        println!("{}", serialized);
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Runtime {}
 
 impl Default for Runtime {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl ExecutableStatus {
-    pub fn raw(&mut self) {
-        println!("{:?}", self);
-    }
-
-    pub fn json(&mut self) {
-        let serialized = serde_json::to_string_pretty(&self).unwrap();
-        println!("{}", serialized);
     }
 }
 


### PR DESCRIPTION
Created a `Getters` and `Setters` macro to eliminate what looks like boilerplate code.

For now the macros only work on `struct` types with named fields (like the generated gRPC types). Fields can also have a `getset` attribute with options. Current options:
- `ignore_get` (don't generate getter)
- `ignore_set` (don't generate setter)
- `ignore` (don't generate getter or setter)

Usage looks like:
```rust
#[derive(macros::Getters, macros::Setters)
struct Executable {
    #[getset(ignore)]
    meta: Meta,
    name: String
}
```

There is also a [getset](https://docs.rs/getset/0.1.2/getset/) crate, but it didn't seem like it would match the project needs. 