### PR TITLE
Improve Getters/Setters macros type compatibility

### DIFF
--- a/macros/src/get_set.rs
+++ b/macros/src/get_set.rs
@@ -1,0 +1,311 @@
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::{quote, ToTokens};
+use std::str::FromStr;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{parse_macro_input, Data, DeriveInput, Field, Token, Type};
+
+pub(crate) fn getters(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let ident = &ast.ident;
+
+    let data_struct = match ast.data {
+        Data::Struct(data_struct) => data_struct,
+        _ => panic!("`Getters` only supports structs"),
+    };
+
+    let field_getters: Vec<proc_macro2::TokenStream> = data_struct
+        .fields
+        .iter()
+        .filter(|field| {
+            !GetSetAttribute::contains_any(field, &["ignore", "ignore_get"])
+        })
+        .map(|field| {
+            let field_ident = field
+                .ident
+                .as_ref()
+                .expect("`Getters` only supports structs with named fields");
+
+            let function_ident =
+                Ident::new(&format!("get_{}", field_ident), field_ident.span());
+
+            let field_type = &field.ty;
+            assert_field_type_is_supported(field_type);
+
+            if try_field_type_as_vec_type_name(field_type).is_some() {
+                quote! {
+                    pub fn #function_ident(&mut self) -> ::rhai::Array {
+                        self.#field_ident
+                            .iter()
+                            .map(|x| ::rhai::Dynamic::from(x.clone()))
+                            .collect()
+                    }
+                }
+            } else {
+                let value_as_rhai_field_type =
+                    match &*field_type_to_name(field_type) {
+                        "f64" | "bool" => {
+                            quote!(::rhai::Dynamic::from(self.#field_ident))
+                        }
+                        "i32" | "i64" | "u32" => {
+                            quote!(::rhai::Dynamic::from(self.#field_ident as i64))
+                        }
+                        other if other.starts_with("::core::option::Option<::prost::alloc::boxed::Box<") => {
+                            quote! {
+                                match &self.#field_ident {
+                                    Some(#field_ident) => rhai::Dynamic::from((**#field_ident).clone()),
+                                    None => rhai::Dynamic::UNIT,
+                                }
+                            }
+                        }
+                        other if other.starts_with("::core::option::Option<") => {
+                            quote! {
+                                match &self.#field_ident {
+                                    Some(#field_ident) => rhai::Dynamic::from((*#field_ident).clone()),
+                                    None => rhai::Dynamic::UNIT,
+                                }
+                            }
+                        }
+                        _ => {
+                            quote!(::rhai::Dynamic::from(self.#field_ident.clone()))
+                        }
+                    };
+
+                quote! {
+                    pub fn #function_ident(&mut self) -> ::rhai::Dynamic {
+                        #value_as_rhai_field_type
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let expanded = quote! {
+        impl #ident {
+            #(#field_getters)*
+        }
+    };
+
+    expanded.into()
+}
+
+pub fn setters(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let ident = &ast.ident;
+
+    let data_struct = match ast.data {
+        Data::Struct(data_struct) => data_struct,
+        _ => panic!("`Setters` only supports structs"),
+    };
+
+    let field_setters: Vec<proc_macro2::TokenStream> = data_struct
+        .fields
+        .iter()
+        .filter(|field| {
+            !GetSetAttribute::contains_any(field, &["ignore", "ignore_set"])
+        })
+        .map(|field| {
+            let field_ident = field
+                .ident
+                .as_ref()
+                .expect("`Setters` only supports structs with named fields");
+
+            let function_ident =
+                Ident::new(&format!("set_{}", field_ident), field_ident.span());
+
+            let field_type = &field.ty;
+            assert_field_type_is_supported(field_type);
+
+            if let Some(vec_of_type_name) = try_field_type_as_vec_type_name(field_type) {
+                let val_as_rust_field_type = expression_for_val_as_rust_field_type(
+                    field_type,
+                    &format!("Unexpected type in array. Expecting {}", vec_of_type_name)
+                );
+
+                quote! {
+                    pub fn #function_ident(&mut self, #field_ident: ::rhai::Array) {
+                        self.#field_ident = #field_ident
+                            .into_iter()
+                            .map(|val| #val_as_rust_field_type)
+                            .collect();
+                    }
+                }
+            } else {
+                let val_as_rust_field_type = expression_for_val_as_rust_field_type(
+                    field_type,
+                    &format!("Unexpected type. Expecting {}", field_type_to_name(field_type))
+                );
+
+                quote! {
+                    pub fn #function_ident(&mut self, val: ::rhai::Dynamic) {
+                        self.#field_ident = #val_as_rust_field_type;
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let expanded = quote! {
+        impl #ident {
+            #(#field_setters)*
+        }
+    };
+
+    return expanded.into();
+
+    fn expression_for_val_as_rust_field_type(
+        field_type: &Type,
+        expect_message: &str,
+    ) -> proc_macro2::TokenStream {
+        let field_type_name = if let Some(vec_of_field_type_name) =
+            try_field_type_as_vec_type_name(field_type)
+        {
+            vec_of_field_type_name
+        } else {
+            field_type_to_name(field_type)
+        };
+
+        // val is of type rhai::Dynamic
+        match &*field_type_name {
+            "f64" => quote!(val.as_float().expect(#expect_message)),
+            "i64" => quote!(val.as_int().expect(#expect_message)),
+            "i32" | "u32" => quote!({
+                let val = val.as_int().expect(#expect_message);
+                ::std::convert::TryFrom::<i64>::try_from(val).expect(#expect_message)
+            }),
+            "bool" => quote!(val.as_bool().expect(#expect_message)),
+            "String" => quote!(val.into_string().expect(#expect_message)),
+            "Vec<u8>" => quote!(val.into_blob().expect(#expect_message)),
+            assuming_proto_message => {
+                if assuming_proto_message.starts_with(
+                    "::core::option::Option<::prost::alloc::boxed::Box<",
+                ) {
+                    let field_type = proto_message_name_to_type(&assuming_proto_message
+                        ["::core::option::Option<::prost::alloc::boxed::Box<".len()
+                        ..assuming_proto_message.len() - 2]);
+
+                    quote!({
+                        match val.as_unit() {
+                            Ok(_) => None,
+                            Err(_) => Some(Box::new(val.cast::<#field_type>())),
+                        }
+                    })
+                } else if assuming_proto_message
+                    .starts_with("::core::option::Option<")
+                {
+                    let field_type = proto_message_name_to_type(
+                        &assuming_proto_message["::core::option::Option<".len()
+                            ..assuming_proto_message.len() - 1],
+                    );
+
+                    quote!({
+                        match val.as_unit() {
+                            Ok(_) => None,
+                            Err(_) => Some(val.cast::<#field_type>()),
+                        }
+                    })
+                } else {
+                    let field_type =
+                        proto_message_name_to_type(assuming_proto_message);
+
+                    quote!(val.cast::<#field_type>())
+                }
+            }
+        }
+    }
+
+    fn proto_message_name_to_type(name: &str) -> proc_macro2::TokenStream {
+        proc_macro2::TokenStream::from_str(name)
+            .unwrap_or_else(|_| panic!("Could not parse type `{}`", name))
+    }
+}
+
+fn field_type_to_name(field_type: &Type) -> String {
+    let field_type_name: String = field_type
+        .to_token_stream()
+        .to_string()
+        .chars()
+        .filter(|x| !x.is_whitespace())
+        .collect();
+
+    match &*field_type_name {
+        "::prost::alloc::string::String" => "String".to_string(),
+        "::prost::alloc::vec::Vec<u8>" => "Vec<u8>".to_string(),
+        _ => field_type_name,
+    }
+}
+
+fn try_field_type_as_vec_type_name(field_type: &Type) -> Option<String> {
+    let field_type_name = field_type_to_name(field_type);
+    if field_type_name.starts_with("::prost::alloc::vec::Vec<") {
+        let field_type_name = match &field_type_name
+            ["::prost::alloc::vec::Vec<".len()..field_type_name.len() - 1]
+        {
+            "::prost::alloc::string::String" => "String",
+            "::prost::alloc::vec::Vec<u8>" => "Vec<u8>",
+            other => other,
+        };
+
+        Some(field_type_name.to_string())
+    } else {
+        None
+    }
+}
+
+fn assert_field_type_is_supported(field_type: &Type) {
+    let field_type_name = if let Some(field_type_name) =
+        try_field_type_as_vec_type_name(field_type)
+    {
+        field_type_name
+    } else {
+        field_type_to_name(field_type)
+    };
+
+    match &*field_type_name {
+        "f32" => panic!("Protobuf float fields are not supported. AuraeScript only has f64, and f64 cannot be cast to f32 without losing precision"),
+        "u64" => panic!("Protobuf uint64 and fixed64 fields are not supported. AuraeScript only has i64, and u64 cannot be cast to i64 safely"),
+        _ => {}
+    };
+}
+
+struct GetSetAttribute {
+    options: Punctuated<Ident, Token![,]>,
+}
+
+impl GetSetAttribute {
+    fn contains_any(field: &Field, values: &[&str]) -> bool {
+        field
+            .attrs
+            .iter()
+            .filter(|attribute| {
+                let seg = match attribute.path.segments.len() {
+                    1 => &attribute.path.segments[0],
+                    2 if attribute.path.segments[0].ident == "macros" => {
+                        &attribute.path.segments[1]
+                    }
+                    _ => {
+                        return false;
+                    }
+                };
+
+                seg.ident == "getset"
+            })
+            .any(|attribute| {
+                let GetSetAttribute { options } = attribute
+                    .parse_args_with(GetSetAttribute::parse)
+                    .expect("failed to parse `getset` attribute");
+
+                options
+                    .into_iter()
+                    .any(|option| values.iter().any(|v| option == v))
+            })
+    }
+}
+
+impl Parse for GetSetAttribute {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let options = input.parse_terminated(Ident::parse)?;
+        Ok(GetSetAttribute { options })
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,8 +1,8 @@
 use proc_macro::TokenStream;
-use proc_macro2::Ident;
-use quote::{quote, ToTokens};
-use syn::spanned::Spanned;
-use syn::{parse_macro_input, Data, DeriveInput};
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+mod get_set;
 
 #[proc_macro_derive(Output)]
 pub fn output(input: TokenStream) -> TokenStream {
@@ -25,208 +25,38 @@ pub fn output(input: TokenStream) -> TokenStream {
     expanded.into()
 }
 
+/// Creates getter functions for all struct fields.
+///
+/// Example:
+/// ```
+/// #[derive(::macros::Getters)]
+/// struct MyStruct {
+///     field_a: String,
+///     #[getset(ignore_get)]
+///     field_no_getter: String,
+///     #[getset(ignore)]
+///     field_not_getter_or_setter: String,
+/// }
+/// ```
 #[proc_macro_derive(Getters, attributes(getset))]
 pub fn getters(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-    let ident = &ast.ident;
-
-    let data_struct = match ast.data {
-        Data::Struct(data_struct) => data_struct,
-        _ => panic!("`Getters` only supports structs"),
-    };
-
-    let field_getters: Vec<proc_macro2::TokenStream> = data_struct
-        .fields
-        .iter()
-        .filter(|field| {
-            !getset::attribute_contains_any(field, &["ignore", "ignore_get"])
-        })
-        .map(|field| {
-            let field_ident = field
-                .ident
-                .as_ref()
-                .expect("`Getters` only supports structs with named fields");
-
-            let function_ident =
-                Ident::new(&format!("get_{}", field_ident), field_ident.span());
-
-            let field_type = &field.ty;
-
-            if field_type
-                .to_token_stream()
-                .to_string()
-                .replace(' ', "")
-                .starts_with("::prost::alloc::vec::Vec<")
-            {
-                quote! {
-                    pub fn #function_ident(&mut self) -> ::rhai::Array {
-                        self.#field_ident
-                            .iter()
-                            .map(|x| ::rhai::Dynamic::from(x.clone()))
-                            .collect()
-                    }
-                }
-            } else {
-                quote! {
-                    pub fn #function_ident(&mut self) -> #field_type {
-                        self.#field_ident.clone()
-                    }
-                }
-            }
-        })
-        .collect();
-
-    let expanded = quote! {
-        impl #ident {
-            #(#field_getters)*
-        }
-    };
-
-    expanded.into()
+    get_set::getters(input)
 }
 
+/// Creates setter functions for all struct fields.
+///
+/// Example:
+/// ```
+/// #[derive(::macros::Setters)]
+/// struct MyStruct {
+///     field_a: String,
+///     #[getset(ignore_set)]
+///     field_no_setter: String,
+///     #[getset(ignore)]
+///     field_not_getter_or_setter: String,
+/// }
+/// ```
 #[proc_macro_derive(Setters, attributes(getset))]
 pub fn setters(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
-    let ident = &ast.ident;
-
-    let data_struct = match ast.data {
-        Data::Struct(data_struct) => data_struct,
-        _ => panic!("`Setters` only supports structs"),
-    };
-
-    let field_setters: Vec<proc_macro2::TokenStream> = data_struct
-        .fields
-        .iter()
-        .filter(|field| {
-            !getset::attribute_contains_any(field, &["ignore", "ignore_set"])
-        })
-        .map(|field| {
-            let field_ident = field
-                .ident
-                .as_ref()
-                .expect("`Setters` only supports structs with named fields");
-
-            let function_ident =
-                Ident::new(&format!("set_{}", field_ident), field_ident.span());
-
-            let field_type = &field.ty;
-
-            let field_type_name = field_type.to_token_stream().to_string().replace(' ', "");
-            if field_type_name.starts_with("::prost::alloc::vec::Vec<") {
-                let vec_of_type_name = &field_type_name["::prost::alloc::vec::Vec<".len()..field_type_name.len() - 1];
-                let expect_message = format!("Unexpected type in array. Expecting {}", vec_of_type_name);
-                let rhai_dynamic_to_rust_fn = match vec_of_type_name {
-                    "f64" => quote!(val.as_float().expect(#expect_message)),
-                    "f32" => panic!("Protobuf float fields are not supported. AuraeScript only has f64, and f64 cannot be cast to f32 without losing precision"),
-                    "i32" => quote!({
-                        let val = val.as_int().expect(#expect_message);
-                        let val: i32 =::std::convert::TryFrom::<i64>::try_from(val).expect(#expect_message);
-                        val
-                    }),
-                    "i64" => quote!(val.as_int().expect(#expect_message)),
-                    "u32" => quote!({
-                        let val = val.as_int().expect(#expect_message);
-                        let val: u32 =::std::convert::TryFrom::<i64>::try_from(val).expect(#expect_message);
-                        val
-                    }),
-                    "u64" => quote!({
-                        let val = val.as_int().expect(#expect_message);
-                        let val: u64 =::std::convert::TryFrom::<i64>::try_from(val).expect(#expect_message);
-                        val
-                    }),
-                    "bool" => quote!(val.as_bool().expect(#expect_message)),
-                    "::prost::alloc::string::String" => {
-                        let expect_message = "Unexpected type in array. Expecting String";
-                        quote!(val.into_string().expect(#expect_message)) 
-                    },
-                    "::prost::alloc::vec::Vec<u8>" => {
-                        let expect_message = "Unexpected type in array. Expecting [u8]";
-                        quote!(val.into_blob().expect(#expect_message)) 
-                    },
-                    assuming_proto_message => {
-                        let ident = assuming_proto_message
-                            .split("::").map(|x| Ident::new(x, field_type.span()));
-                        quote!({
-                            val.cast::<#(#ident)::*>()
-                        })
-                    }
-                };
-
-                quote! {
-                    pub fn #function_ident(&mut self, #field_ident: ::rhai::Array) {
-                        let mut vals = vec![];
-                        for val in #field_ident.into_iter() {
-                            let val = #rhai_dynamic_to_rust_fn;
-                            vals.push(val);
-                        }
-                        self.#field_ident = vals;
-                    }
-                }
-            } else {
-                quote! {
-                    pub fn #function_ident(&mut self, #field_ident: #field_type) {
-                        self.#field_ident = #field_ident;
-                    }
-                }
-            }
-        })
-        .collect();
-
-    let expanded = quote! {
-        impl #ident {
-            #(#field_setters)*
-        }
-    };
-
-    expanded.into()
-}
-
-mod getset {
-    use proc_macro2::Ident;
-    use syn::parse::{Parse, ParseStream};
-    use syn::punctuated::Punctuated;
-    use syn::{Field, Token};
-
-    struct GetSetAttribute {
-        options: Punctuated<Ident, Token![,]>,
-    }
-
-    impl Parse for GetSetAttribute {
-        fn parse(input: ParseStream) -> syn::Result<Self> {
-            let options = input.parse_terminated(Ident::parse)?;
-            Ok(GetSetAttribute { options })
-        }
-    }
-
-    pub(crate) fn attribute_contains_any(
-        field: &Field,
-        values: &[&str],
-    ) -> bool {
-        field
-            .attrs
-            .iter()
-            .filter(|attribute| {
-                let seg = match attribute.path.segments.len() {
-                    1 => &attribute.path.segments[0],
-                    2 if attribute.path.segments[0].ident == "macros" => {
-                        &attribute.path.segments[1]
-                    }
-                    _ => {
-                        return false;
-                    }
-                };
-
-                seg.ident == "getset"
-            })
-            .any(|attribute| {
-                let GetSetAttribute { options } = attribute
-                    .parse_args_with(GetSetAttribute::parse)
-                    .expect("failed to parse `getset` attribute");
-
-                options
-                    .into_iter()
-                    .any(|option| values.iter().any(|v| option == v))
-            })
-    }
+    get_set::setters(input)
 }


### PR DESCRIPTION
This should make the getters/setters support repeated fields with the exception of proto floats. I did light manual testing and it was working.

The pr can be merged if someone needs it (it is an improvement over the previous code), but I still need to organize/iterate it and test non-repeated types (e.g., non-repeated floats aren't currently panicking).